### PR TITLE
chore(deps): bump path-to-regexp, qs

### DIFF
--- a/packages/mezon-chat-widget/development/package-lock.json
+++ b/packages/mezon-chat-widget/development/package-lock.json
@@ -851,9 +851,9 @@
          }
       },
       "node_modules/path-to-regexp": {
-         "version": "8.3.0",
-         "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-         "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+         "version": "8.4.2",
+         "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+         "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
          "dev": true,
          "license": "MIT",
          "funding": {
@@ -876,9 +876,9 @@
          }
       },
       "node_modules/qs": {
-         "version": "6.14.1",
-         "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-         "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+         "version": "6.15.1",
+         "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+         "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
          "dev": true,
          "license": "BSD-3-Clause",
          "dependencies": {


### PR DESCRIPTION
Updated dependencies in mezon-chat-widget/development/package-lock.json:
- path-to-regexp from 8.3.0 to 8.4.2
- qs from 6.14.1 to 6.15.1